### PR TITLE
Re-introduce the multiplayer bug as a config

### DIFF
--- a/RiskOfRumble/Plugin.cs
+++ b/RiskOfRumble/Plugin.cs
@@ -229,9 +229,15 @@ namespace RiskOfRumble
             }
         }
 
+        
+        private CharacterMaster GetCharacterMaster()
+        {
+            return LocalUserManager.GetFirstLocalUser().currentNetworkUser.master;
+        }
+
         private void Punish(DamageDealtMessage obj)
         {
-            var playermaster = PlayerCharacterMasterController.instances[0].master;
+            var playermaster = GetCharacterMaster();
             if (!playermaster)
             {
                 return;
@@ -255,7 +261,7 @@ namespace RiskOfRumble
 
         private void Reward(DamageDealtMessage obj)
         {
-            var playermaster = PlayerCharacterMasterController.instances[0].master;
+            var playermaster = GetCharacterMaster();
             if (!playermaster)
             {
                 return;

--- a/RiskOfRumble/Plugin.cs
+++ b/RiskOfRumble/Plugin.cs
@@ -77,7 +77,7 @@ namespace RiskOfRumble
 
             Rewarding = Config.Bind("Gameplay", "Rewarding", true, "If rewarding actions (hitting things) should trigger vibrations");
             Punishing = Config.Bind("Gameplay", "Punishing", false, "If punishing actions (getting hit) should trigger vibrations");
-            RoundRobin = Config.Bind("Gameplay", "Round Robin", false, "If you should recieve rewards/punishments from another players actions");
+            RoundRobin = Config.Bind("Gameplay", "Round Robin", false, "If you should receive rewards/punishments from another players actions");
             RewardFactor = Config.Bind("Gameplay", "Reward Factor", 0.5f, "The reward multiplier");
             PunishmentFactor = Config.Bind("Gameplay", "Punishment Factor", 2f, "The punishment multiplier");
         }

--- a/RiskOfRumble/Plugin.cs
+++ b/RiskOfRumble/Plugin.cs
@@ -26,6 +26,7 @@ namespace RiskOfRumble
 
         public static ConfigEntry<bool> Rewarding;
         public static ConfigEntry<bool> Punishing;
+        public static ConfigEntry<bool> RoundRobin;
         public static ConfigEntry<float> RewardFactor;
         public static ConfigEntry<float> PunishmentFactor;
 
@@ -76,6 +77,7 @@ namespace RiskOfRumble
 
             Rewarding = Config.Bind("Gameplay", "Rewarding", true, "If rewarding actions (hitting things) should trigger vibrations");
             Punishing = Config.Bind("Gameplay", "Punishing", false, "If punishing actions (getting hit) should trigger vibrations");
+            RoundRobin = Config.Bind("Gameplay", "Round Robin", false, "If you should recieve rewards/punishments from another players actions");
             RewardFactor = Config.Bind("Gameplay", "Reward Factor", 0.5f, "The reward multiplier");
             PunishmentFactor = Config.Bind("Gameplay", "Punishment Factor", 2f, "The punishment multiplier");
         }
@@ -232,7 +234,22 @@ namespace RiskOfRumble
         
         private CharacterMaster GetCharacterMaster()
         {
-            return LocalUserManager.GetFirstLocalUser().currentNetworkUser.master;
+            var playermaster = LocalUserManager.GetFirstLocalUser().currentNetworkUser.master;
+            if (RoundRobin.Value)
+            {
+                // find our player index
+                var playerIndex = 0;
+                foreach (var networkPlayer in PlayerCharacterMasterController.instances)
+                {
+                    if (networkPlayer.master == playermaster)
+                    {
+                        break;
+                    }
+                    playerIndex++;
+                }
+                playermaster = PlayerCharacterMasterController.instances[(playerIndex + 1) % PlayerCharacterMasterController.instances.Count].master;
+            }
+            return playermaster;
         }
 
         private void Punish(DamageDealtMessage obj)


### PR DESCRIPTION
Adds back in a config value to intentionally re-introduce a more even form of the original bug (receiving rewards/punishments from another player) but this time a 1 player shift in the player list, rather than the host.